### PR TITLE
Add roll/jumbo fields to User deserialization

### DIFF
--- a/dicers_bot/user.py
+++ b/dicers_bot/user.py
@@ -45,6 +45,8 @@ class User:
     def deserialize(cls, json: Dict[str, Any]):
         user = User(json.get("name"), json.get("id"))
         user.muted = json.get("muted", False)
+        user.roll = int(json.get("roll", -1))
+        user.jumbo = bool(json.get("jumbo", False))
 
         return user
 


### PR DESCRIPTION
Every time we restart the bot, it loses all data for user rolls.