### PR TITLE
Refactor with telegram sdk version 12.0.0b

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       - setup_remote_docker
       - run: docker login -u $DOCKER_USER -p $DOCKER_PASS
 
-      - run: sed -i -e "s/{{VERSION}}/$CIRCLE_SHA1/" main.py
+      - run: sed -i -e "s/{{VERSION}}/$CIRCLE_SHA1/" dicers_bot/bot.py
 
       # build the application image
       - run: docker build -t openalcoholics/regular_dicers_bot:latest-$CIRCLE_BRANCH .

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This settings should be disabled if you want the spam detection to work.
 
 ## Installation
 
+This project needs python3.7
+
 ### Virtualenv
 
 ```bash

--- a/commands.md
+++ b/commands.md
@@ -1,6 +1,7 @@
 ```
 register_main - Register the main chat (can create calendar events and is the admin chat)
 unregister_main - Unregisters this chat as the main chat (now every other chat has the possibility to become the main chat)
+delete_chat - Deletes all data associated with this chat (admin command)
 remind_me - Show the attendance keyboard
 remind_all - Show attendance keyboards for all known chats (admin command)
 show_dice - Show the dice keyboard

--- a/commands.md
+++ b/commands.md
@@ -1,7 +1,6 @@
 ```
-register - Register the chat
 register_main - Register the main chat (can create calendar events and is the admin chat)
-unregister - Remove the chat from the bot
+unregister_main - Unregisters this chat as the main chat (now every other chat has the possibility to become the main chat)
 remind_me - Show the attendance keyboard
 remind_all - Show attendance keyboards for all known chats (admin command)
 show_dice - Show the dice keyboard

--- a/dicers_bot/__init__.py
+++ b/dicers_bot/__init__.py
@@ -1,5 +1,5 @@
 from .bot import Bot
-from .chat import Chat
 from .calendar import Calendar
+from .chat import Chat
 from .logger import create_logger
 from .user import User

--- a/dicers_bot/__init__.py
+++ b/dicers_bot/__init__.py
@@ -1,3 +1,5 @@
 from .bot import Bot
+from .chat import Chat
 from .calendar import Calendar
 from .logger import create_logger
+from .user import User

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -221,12 +221,7 @@ class Bot:
         chat = context.chat_data["chat"]
         self.logger.debug(f"Attempting to reset {chat.id}")
 
-        result = chat.reset()
-
-        message = "Success" if result else "Failed to reset chat"
-        update.message.reply_text(message, notification=False)
-
-        return result
+        chat.reset()
 
     @Command(main_admin=True)
     def reset_all(self, update: Update, context: CallbackContext):

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -191,6 +191,12 @@ class Bot:
             sentry_sdk.capture_exception()
             self.logger.exception(e)
 
+        user_has_voted_already = (user in chat.current_event.attendees) or (user in chat.current_event.absentees)
+        if not user_has_voted_already:
+            vote_count: int = len(chat.current_event.attendees) + len(chat.current_event.absentees)
+            if len(chat.users) == vote_count and vote_count > 1:
+                self.send_message(chat_id=chat.id, text="Alle haben abgestimmt.")
+
     @Command()
     def handle_dice_callback(self, update: Update, context: CallbackContext) -> Dict:
         callback: CallbackQuery = update.callback_query

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from itertools import groupby, zip_longest
 from threading import Timer
-from typing import Any, List, Optional, Dict, Iterable, Set
+from typing import Any, List, Optional, Dict, Iterable, Set, Tuple, Sequence
 
 import sentry_sdk
 from telegram import ParseMode, TelegramError, Update, CallbackQuery, Message
@@ -18,7 +18,7 @@ from .calendar import Calendar
 from .logger import create_logger
 
 
-def grouper(iterable, n, fillvalue=None):
+def grouper(iterable, n, fillvalue=None) -> Iterable[Tuple[Any, Any]]:
     """Collect data into fixed-length chunks or blocks"""
     args = [iter(iterable)] * n
     return zip_longest(*args, fillvalue=fillvalue)
@@ -43,12 +43,12 @@ class Bot:
         self.config = Config("config.json")
 
     @Command()
-    def show_dice(self, update: Update, context: CallbackContext):
+    def show_dice(self, update: Update, context: CallbackContext) -> Optional[Message]:
         chat = context.chat_data["chat"]
         return chat.show_dice()
 
     @Command(main_admin=True)
-    def show_dice_keyboards(self, update: Optional[Update], context: Optional[CallbackContext]):
+    def show_dice_keyboards(self, update: Optional[Update], context: Optional[CallbackContext]) -> None:
         for chat_id in self.chats.keys():
             self.hide_attend(chat_id)
             if context:
@@ -56,19 +56,20 @@ class Bot:
             elif chat_id in self.chats:
                 self.chats.get(chat_id).show_dice()
             else:
-                self.logger.warning(f"Can't show keyboard for {chat_id}, `context` is `None` and `chat_id` is not in `self.chats`.")
+                self.logger.warning(
+                    f"Can't show keyboard for {chat_id}, `context` is `None` and `chat_id` is not in `self.chats`.")
 
-    def hide_attend(self, chat_id):
+    def hide_attend(self, chat_id) -> bool:
         chat: Chat = self.chats[chat_id]
         return chat.hide_attend()
 
-    def save_state(self):
+    def save_state(self) -> None:
         self.state["chats"] = [chat.serialize() for chat in self.chats.values()]
         with open("state.json", "w+") as f:
             json.dump(self.state, f)
 
     @Command(chat_admin=True)
-    def delete_chat(self, update: Update, context: CallbackContext):
+    def delete_chat(self, update: Update, context: CallbackContext) -> None:
         chat: Chat = context.chat_data["chat"]
 
         if chat.id in self.chats:
@@ -77,7 +78,7 @@ class Bot:
             del context.chat_data["chat"]
 
     @Command()
-    def register_main(self, update: Update, context: CallbackContext):
+    def register_main(self, update: Update, context: CallbackContext) -> Message:
         self.logger.info("Register main")
         chat = context.chat_data["chat"]
         user = context.user_data["user"]
@@ -98,16 +99,16 @@ class Bot:
                 self.logger.debug("User tries to register a main_chat despite of there being an existing one")
                 message = "You can't register as the main chat, since there already is one."
 
-        update.message.reply_text(text=message)
+        return update.message.reply_text(text=message)
 
     @Command(main_admin=True)
-    def unregister_main(self, update: Update, context: CallbackContext):
+    def unregister_main(self, update: Update, context: CallbackContext) -> Message:
         self.logger.info("Unregistering main chat")
         self.state["main_id"] = None
 
-        update.message.reply_text(text="You've been unregistered as the main chat")
+        return update.message.reply_text(text="You've been unregistered as the main chat")
 
-    def set_user_restriction(self, chat_id: str, user: User, until_date: timedelta, **kwargs):
+    def set_user_restriction(self, chat_id: str, user: User, until_date: timedelta, **kwargs) -> bool:
         timestamp: int = int((datetime.now() + until_date).timestamp())
         try:
             result = self.updater.bot.restrict_chat_member(chat_id, user.id, until_date=timestamp,
@@ -127,18 +128,27 @@ class Bot:
 
         return result
 
-    def unmute_user(self, chat_id: str, user: User):
+    def unmute_user(self, chat_id: str, user: User) -> bool:
+        result = False
+
         try:
             if self.updater.bot.promote_chat_member(chat_id, user.id, can_post_messages=True):
                 user.muted = False
+                result = True
         except TelegramError:
             self.logger.error("Error while promoting chat member", exc_info=True)
 
-    def mute_user(self, chat_id: str, user: User, until_date: timedelta, reason: Optional[str] = None):
+        return result
+
+    def mute_user(self, chat_id: str, user: User, until_date: timedelta, reason: Optional[str] = None) -> bool:
+        result = False
         self.logger.info(f"Reason for muting: {reason}")
         if self.set_user_restriction(chat_id, user, until_date=until_date, can_send_messages=False):
             user.muted = True
+            result = True
             # We'd need to parse the exception before assigning user.muted differently
+
+        return result
 
     # noinspection PyUnusedLocal
     @Command(main_admin=True)
@@ -147,14 +157,14 @@ class Bot:
         return all([bool(chat.show_attend_keyboard()) for chat in self.chats.values()])
 
     @Command()
-    def handle_attend_callback(self, update: Update, context: CallbackContext):
+    def handle_attend_callback(self, update: Update, context: CallbackContext) -> bool:
         callback: CallbackQuery = update.callback_query
         user = context.user_data["user"]
         chat: Chat = context.chat_data["chat"]
 
         chat.set_attend_callback(callback)
 
-        def _mute_user_if_absent():
+        def _mute_user_if_absent() -> None:
             if user in chat.current_event.absentees:
                 self.mute_user(chat.id, user, timedelta(hours=1))
 
@@ -196,8 +206,10 @@ class Bot:
             if len(chat.users) == vote_count and vote_count > 1:
                 self.send_message(chat_id=chat.id, text="Alle haben abgestimmt.")
 
+        return True
+
     @Command()
-    def handle_dice_callback(self, update: Update, context: CallbackContext) -> Dict:
+    def handle_dice_callback(self, update: Update, context: CallbackContext) -> None:
         callback: CallbackQuery = update.callback_query
         user = context.user_data["user"]
         chat: Chat = context.chat_data["chat"]
@@ -211,7 +223,7 @@ class Bot:
             message = f"You ({user.name}) are not attending this event, you can't roll a dice yet."
             self.send_message(chat_id=chat.id, text=message)
             callback.answer()
-            return {}
+            return
 
         attendee = [attendee for attendee in attendees if attendee.id == user.id][0]
 
@@ -221,7 +233,7 @@ class Bot:
         else:
             attendee.set_jumbo(data == "+1")
 
-        return chat.update_dice_message()
+        chat.update_dice_message()
 
     @Command()
     def remind_chat(self, update: Update, context: CallbackContext) -> bool:
@@ -237,41 +249,56 @@ class Bot:
         return bool(result)
 
     @Command(chat_admin=True)
-    def reset(self, update: Update, context: CallbackContext) -> None:
+    def reset(self, update: Update, context: CallbackContext) -> bool:
         chat = context.chat_data["chat"]
         self.logger.debug(f"Attempting to reset {chat.id}")
+        message = "Reset has been performed successfully."
+        result = True
 
         try:
             chat.reset()
         except TelegramError:
             self.logger.warning(f"Could not reset for chat {chat.id}", exc_info=True)
-            update.message.reply_text(chat_id=chat.id, text="Could not perform reset.")
+            message = "Could not perform reset."
+            result = False
+
+        update.message.reply_text(chat_id=chat.id, text=message)
+
+        return result
 
     @Command(main_admin=True)
-    def reset_all(self, update: Optional[Update], context: Optional[CallbackContext]):
+    def reset_all(self, update: Optional[Update], context: Optional[CallbackContext]) -> bool:
         self.logger.debug("Attempting to reset all chats")
 
         success = {}
         for chat in self.chats.values():
+            message = "Reset has been performed successfully."
             try:
                 chat.reset()
                 success[chat.id] = True
             except TelegramError:
                 success[chat.id] = False
                 self.logger.warning(f"Could not reset for chat {chat.id}", exc_info=True)
-                update.message.reply_text(chat_id=chat.id, text="Could not perform reset.")
+                message = "Could not perform reset."
 
+            if update:
+                update.message.reply_text(chat_id=chat.id, text=message)
+
+        result = True
         if all(value for _, value in success.items()):
             message = "Success"
         else:
             message = "Failure for the following chats:\n{}".format(
                 [chat_id for chat_id, suc in success.items() if not suc]
             )
+            result = False
 
         if update:
             update.message.reply_text(text=message, disable_notification=True)
 
-    def check_for_spam(self, chat_messages: Dict[Chat, Iterable[Message]]):
+        return result
+
+    def check_for_spam(self, chat_messages: Dict[Chat, Iterable[Message]]) -> None:
         for chat, messages in chat_messages.items():
             user_messages = dict((chat.get_user_by_id(user_id), set(user_messages)) for user_id, user_messages in
                                  groupby(messages, lambda message: message.from_user.id))
@@ -309,14 +336,14 @@ class Bot:
         different_message_limit: int = spam_config.get("different_message_limit", 15)
         different_message_timeframe: int = spam_config.get("different_message_timeframe", 2)
 
-        def is_consecutive(sorted_messages: List[Optional[Message]]):
+        def is_consecutive(sorted_messages: Sequence[Optional[Message]]) -> bool:
             if None in sorted_messages:
                 return False
             minimum = sorted_messages[0].message_id
             maximum = sorted_messages[-1].message_id
 
-            return sum([message.message_id for message in sorted_messages]) == maximum * (maximum + 1) / 2 - (
-                    (minimum - 1) * (minimum / 2))
+            return bool(sum([message.message_id for message in sorted_messages]) == maximum * (maximum + 1) / 2 - (
+                    (minimum - 1) * (minimum / 2)))
 
         first = user_messages[0].date
         last = user_messages[-1].date
@@ -343,7 +370,7 @@ class Bot:
         return SpamType.NONE
 
     @Command()
-    def handle_message(self, update: Update, context: CallbackContext):
+    def handle_message(self, update: Update, context: CallbackContext) -> None:
         self.logger.info("Handle message: {}".format(update.message.text))
         chat: Chat = context.chat_data["chat"]
 
@@ -360,12 +387,10 @@ class Bot:
         if update.message.left_chat_member.id != self.updater.bot.id:
             update.message.reply_text("Bye bye birdie")
 
-    def set_state(self, state: Dict[str, Any]):
+    def set_state(self, state: Dict[str, Any]) -> None:
         self.state = state
         self.state["main_id"] = self.state.get("main_id", "")
         self.chats = {schat["id"]: Chat.deserialize(schat, self.updater.bot) for schat in state.get("chats", [])}
-
-        return True
 
     def send_message(self, *args, **kwargs) -> Message:
         return self.updater.bot.send_message(*args, **kwargs)
@@ -383,20 +408,19 @@ class Bot:
 
     @Command()
     def new_member(self, update: Update, context: CallbackContext):
-        pass
+        chat = context.chat_data["chat"]
+
+        self.logger.info(f"A new member ({update.effective_user}) has joined this chat ({chat.id})")
 
     @Command()
-    def status(self, update: Update, context: CallbackContext):
-        try:
-            update.message.reply_text(text=f"{context.chat_data['chat']}")
-        except Exception as e:
-            pass
+    def status(self, update: Update, context: CallbackContext) -> Message:
+        return update.message.reply_text(text=f"{context.chat_data['chat']}")
 
     @Command()
-    def version(self, update: Update, context: CallbackContext):
-        update.message.reply_text("{{VERSION}}")
+    def version(self, update: Update, context: CallbackContext) -> Message:
+        return update.message.reply_text("{{VERSION}}")
 
     @Command()
-    def server_time(self, update: Update, context: CallbackContext):
+    def server_time(self, update: Update, context: CallbackContext) -> Message:
         time = datetime.now().strftime("%d-%m-%Y %H-%M-%S")
-        update.message.reply_text(time)
+        return update.message.reply_text(time)

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -324,6 +324,21 @@ class Bot:
         else:
             self.logger.info("Handled message")
 
+    @Command()
+    def handle_left_chat_member(self, update: Update, context: CallbackContext) -> None:
+        chat: Chat = context.chat_data["chat"]
+
+        if update.message.left_chat_member.id == self.updater.bot.id:
+            self.logger.info(f"Bot was removed from {chat}.\nRemoving all chat data.")
+
+            if chat.id in self.chats:
+                self.logger.info(f"Deleting chat ({chat}) from state.")
+                del self.chats[chat.id]
+            else:
+                self.logger.warning(f"{chat} was not found in `self.chats` despite just being kicked.")
+        else:
+            update.message.reply_text("Bye bye birdie")
+
     def set_state(self, state: Dict[str, Any]):
         self.state = state
         self.state["main_id"] = self.state.get("main_id", "")

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -76,6 +76,7 @@ class Bot:
         if chat.id in self.chats:
             self.logger.info(f"Deleting chat ({chat}) from state.")
             del self.chats[chat.id]
+            del context.chat_data["chat"]
 
     @Command()
     def register_main(self, update: Update, context: CallbackContext):
@@ -363,15 +364,14 @@ class Bot:
 
     @Command()
     def show_users(self, update: Update, context: CallbackContext) -> Optional[Message]:
-        chat_id = context.chat_data["chat"].id
-        chat = self.chats.get(chat_id)
+        chat = context.chat_data["chat"]
 
         message = "\n".join([str(user) for user in chat.users])
 
         if not message:
             message = "No active users. Users need to write a message in the chat to be recognized (not just a command)"
 
-        return self.updater.bot.send_message(chat_id=chat_id, text=message)
+        return self.send_message(chat_id=chat.id, text=message)
 
     @Command()
     def new_member(self, update: Update, context: CallbackContext):

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -358,7 +358,7 @@ class Bot:
 
         if not message:
             message = "No active users. Users need to write a message in the chat to be recognized (not just a command)"
-        
+
         return self.updater.bot.send_message(chat_id=chat_id, text=message)
 
     @Command()

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -241,7 +241,11 @@ class Bot:
         chat = context.chat_data["chat"]
         self.logger.debug(f"Attempting to reset {chat.id}")
 
-        chat.reset()
+        try:
+            chat.reset()
+        except TelegramError:
+            self.logger.warning(f"Could not reset for chat {chat.id}", exc_info=True)
+            update.message.reply_text(chat_id=chat.id, text="Could not perform reset.")
 
     @Command(main_admin=True)
     def reset_all(self, update: Optional[Update], context: Optional[CallbackContext]):
@@ -249,7 +253,13 @@ class Bot:
 
         success = {}
         for chat in self.chats.values():
-            success[chat.id] = chat.reset()
+            try:
+                chat.reset()
+                success[chat.id] = True
+            except TelegramError:
+                success[chat.id] = False
+                self.logger.warning(f"Could not reset for chat {chat.id}", exc_info=True)
+                update.message.reply_text(chat_id=chat.id, text="Could not perform reset.")
 
         if all(value for _, value in success.items()):
             message = "Success"

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -42,6 +42,10 @@ class Bot:
         self.logger = create_logger("regular_dicers_bot")
         self.config = Config("config.json")
 
+    def _show_dice(self, chat_id: str):
+        if chat_id in self.chats:
+            self.chats.get(chat_id).show_dice()
+
     @Command()
     def show_dice(self, update: Update, context: CallbackContext):
         chat = context.chat_data["chat"]
@@ -51,7 +55,10 @@ class Bot:
     def show_dice_keyboards(self, update: Update, context: CallbackContext):
         for chat_id in self.chats.keys():
             self.hide_attend(chat_id)
-            self.show_dice(update, context)
+            if context:
+                self.show_dice(update, context)
+            else:
+                self._show_dice(chat_id)
 
     def hide_attend(self, chat_id):
         chat: Chat = self.chats[chat_id]
@@ -246,7 +253,8 @@ class Bot:
                 [chat_id for chat_id, suc in success.items() if not suc]
             )
 
-        update.message.reply_text(text=message, disable_notification=True)
+        if update:
+            update.message.reply_text(text=message, disable_notification=True)
 
     def check_for_spam(self, chat_messages: Dict[Chat, Iterable[Message]]):
         for chat, messages in chat_messages.items():

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -62,6 +62,14 @@ class Bot:
         with open("state.json", "w+") as f:
             json.dump(self.state, f)
 
+    @Command(chat_admin=True)
+    def delete_chat(self, update: Update, context: CallbackContext):
+        chat: Chat = context.chat_data["chat"]
+
+        if chat.id in self.chats:
+            self.logger.info(f"Deleting chat ({chat}) from state.")
+            del self.chats[chat.id]
+
     @Command()
     def register_main(self, update: Update, context: CallbackContext):
         self.logger.info("Register main")
@@ -326,17 +334,7 @@ class Bot:
 
     @Command()
     def handle_left_chat_member(self, update: Update, context: CallbackContext) -> None:
-        chat: Chat = context.chat_data["chat"]
-
-        if update.message.left_chat_member.id == self.updater.bot.id:
-            self.logger.info(f"Bot was removed from {chat}.\nRemoving all chat data.")
-
-            if chat.id in self.chats:
-                self.logger.info(f"Deleting chat ({chat}) from state.")
-                del self.chats[chat.id]
-            else:
-                self.logger.warning(f"{chat} was not found in `self.chats` despite just being kicked.")
-        else:
+        if update.message.left_chat_member.id != self.updater.bot.id:
             update.message.reply_text("Bye bye birdie")
 
     def set_state(self, state: Dict[str, Any]):

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -217,7 +217,7 @@ class Bot:
         return bool(result)
 
     @Command(chat_admin=True)
-    def reset(self, update: Update, context: CallbackContext) -> bool:
+    def reset(self, update: Update, context: CallbackContext) -> None:
         chat = context.chat_data["chat"]
         self.logger.debug(f"Attempting to reset {chat.id}")
 

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -262,7 +262,7 @@ class Bot:
             message = "Could not perform reset."
             result = False
 
-        update.message.reply_text(chat_id=chat.id, text=message)
+        update.message.reply_text(text=message)
 
         return result
 
@@ -282,7 +282,7 @@ class Bot:
                 message = "Could not perform reset."
 
             if update:
-                update.message.reply_text(chat_id=chat.id, text=message)
+                update.message.reply_text(text=message)
 
         result = True
         if all(value for _, value in success.items()):

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -42,10 +42,6 @@ class Bot:
         self.logger = create_logger("regular_dicers_bot")
         self.config = Config("config.json")
 
-    def _show_dice(self, chat_id: str):
-        if chat_id in self.chats:
-            self.chats.get(chat_id).show_dice()
-
     @Command()
     def show_dice(self, update: Update, context: CallbackContext):
         chat = context.chat_data["chat"]
@@ -57,8 +53,10 @@ class Bot:
             self.hide_attend(chat_id)
             if context:
                 self.show_dice(update, context)
+            elif chat_id in self.chats:
+                self.chats.get(chat_id).show_dice()
             else:
-                self._show_dice(chat_id)
+                self.logger.warning(f"Can't show keyboard for {chat_id}, `context` is `None` and `chat_id` is not in `self.chats`.")
 
     def hide_attend(self, chat_id):
         chat: Chat = self.chats[chat_id]

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -52,7 +52,7 @@ class Bot:
         return chat.show_dice()
 
     @Command(main_admin=True)
-    def show_dice_keyboards(self, update: Update, context: CallbackContext):
+    def show_dice_keyboards(self, update: Optional[Update], context: Optional[CallbackContext]):
         for chat_id in self.chats.keys():
             self.hide_attend(chat_id)
             if context:
@@ -143,7 +143,7 @@ class Bot:
 
     # noinspection PyUnusedLocal
     @Command(main_admin=True)
-    def remind_users(self, update: Update, context: CallbackContext) -> bool:
+    def remind_users(self, update: Optional[Update], context: Optional[CallbackContext]) -> bool:
         # Check that all chat keyboards have been set correctly
         return all([bool(chat.show_attend_keyboard()) for chat in self.chats.values()])
 
@@ -239,7 +239,7 @@ class Bot:
         chat.reset()
 
     @Command(main_admin=True)
-    def reset_all(self, update: Update, context: CallbackContext):
+    def reset_all(self, update: Optional[Update], context: Optional[CallbackContext]):
         self.logger.debug("Attempting to reset all chats")
 
         success = {}

--- a/dicers_bot/bot.py
+++ b/dicers_bot/bot.py
@@ -9,13 +9,11 @@ from typing import Any, List, Optional, Dict, Iterable, Set
 
 import sentry_sdk
 from telegram import ParseMode, TelegramError, Update, CallbackQuery, Message
-from telegram import User as TUser
-from telegram.error import BadRequest
-from telegram.ext import CallbackContext, Job
+from telegram.ext import CallbackContext
 
 from dicers_bot.chat import Chat, User, Keyboard
 from dicers_bot.config import Config
-from dicers_bot.decorators import admin, Command
+from dicers_bot.decorators import Command
 from .calendar import Calendar
 from .logger import create_logger
 

--- a/dicers_bot/calendar.py
+++ b/dicers_bot/calendar.py
@@ -37,14 +37,14 @@ class Calendar:
             self.logger.warning("Calendar module is disabled. Reason: %s", str(e))
             self.service = None
 
-    def create(self):
+    def create(self) -> None:
         service = self.service
         if not service:
-            return
+            return None
 
         if datetime.today().weekday() != 0:
             print("Not monday ({})".format(datetime.today().weekday()))
-            return
+            return None
         self.fill_base_event()
 
         if self.last_event and self.event["start"]["dateTime"] == self.last_event["start"]["dateTime"]:
@@ -52,14 +52,14 @@ class Calendar:
                 self.event["start"]["dateTime"],
                 self.last_event["start"]["dateTime"])
             )
-            return
+            return None
 
         gevent = service.events().insert(calendarId="43httl0ouo48t260oqturfrs84@group.calendar.google.com",
                                          body=self.event).execute()
         self.last_event = self.event
         self.event = base_event
 
-        return gevent.get("htmlLink")
+        gevent.get("htmlLink")
 
     @staticmethod
     def _load_credentials(filename) -> client.Credentials:
@@ -78,20 +78,20 @@ class Calendar:
         return credentials
 
     @staticmethod
-    def _get_start_time():
+    def _get_start_time() -> datetime:
         today = datetime.today()
         start = today.replace(hour=21, minute=0, second=0, microsecond=0)
 
         return start
 
     @staticmethod
-    def _get_end_time():
+    def _get_end_time() -> datetime:
         today = datetime.today()
         end = today.replace(hour=23, minute=30, second=0, microsecond=0)
 
         return end
 
-    def fill_base_event(self):
+    def fill_base_event(self) -> None:
         date_format = "%Y-%m-%dT%H:%M:%S"
         self.event["start"]["dateTime"] = self._get_start_time().strftime(date_format)
         self.event["end"]["dateTime"] = self._get_end_time().strftime(date_format)

--- a/dicers_bot/chat.py
+++ b/dicers_bot/chat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import Optional, Set, List, Dict
 

--- a/dicers_bot/chat.py
+++ b/dicers_bot/chat.py
@@ -301,7 +301,7 @@ class Chat:
 
         return result
 
-    def administrators(self) -> List[User]:
+    def administrators(self) -> Set[User]:
         """
         Lists all administrators in this chat.
         Skips administrators who are not in `self.users`.
@@ -309,17 +309,17 @@ class Chat:
 
         :return: Administrators in this chat List[User]
         """
-        administrators: List[User] = []
+        administrators: Set[User] = set()
 
         try:
             chat_administrators = self.bot.get_chat_administrators(chat_id=self.id)
-        except TelegramError as e:
-            return []
+        except TelegramError:
+            return administrators
 
         for admin in chat_administrators:
             try:
                 user = next(filter(lambda user: user.id == admin.user.id, self.users))
-                administrators.append(user)
+                administrators.add(user)
             except StopIteration:
                 pass
 

--- a/dicers_bot/chat.py
+++ b/dicers_bot/chat.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Optional, Set, List, Dict, Any
 
 from telegram import Bot as TBot
+from telegram import Chat as TChat
 from telegram import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton, TelegramError
 from telegram.error import BadRequest
 
@@ -16,6 +17,23 @@ class Keyboard(Enum):
     NONE = 0
     ATTEND = 1
     DICE = 2
+
+
+class ChatType(Enum):
+    UNDEFINED = ""
+    PRIVATE = TChat.PRIVATE
+    GROUP = TChat.GROUP
+    SUPERGROUP = TChat.SUPERGROUP
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, str):
+            if isinstance(other, ChatType):
+                return self.value == other.value
+            else:
+                return False
+
+
+        return self.value == other
 
 
 class Chat:
@@ -35,6 +53,7 @@ class Chat:
         self.logger.info("Initialize empty user set")
         self.users: Set[User] = set()
         self.title = None
+        self.type = ChatType.UNDEFINED
 
     def get_user_by_id(self, _id: int) -> Optional[User]:
         result = next(filter(lambda user: user.id == _id, self.users), None)

--- a/dicers_bot/decorators.py
+++ b/dicers_bot/decorators.py
@@ -1,6 +1,5 @@
-from datetime import timedelta
-import functools
 import inspect
+from datetime import timedelta
 
 from telegram import Update
 from telegram.ext import CallbackContext

--- a/dicers_bot/decorators.py
+++ b/dicers_bot/decorators.py
@@ -21,8 +21,8 @@ class Command:
 
         context.chat_data["chat"] = chat
 
-        if not chat.title:
-            chat.title = update.effective_chat.title
+        chat.title = update.effective_chat.title
+        chat.type = update.effective_chat.type
 
         return chat
 
@@ -65,6 +65,7 @@ class Command:
             chat = context.chat_data.get("chat")
             if not chat:
                 chat = self._add_chat(clazz, update, context)
+            chat.type = update.effective_chat.type
 
             if not clazz.chats.get(chat.id):
                 clazz.chats[chat.id] = chat

--- a/dicers_bot/decorators.py
+++ b/dicers_bot/decorators.py
@@ -1,41 +1,112 @@
+from datetime import timedelta
 import functools
+import inspect
+
+from telegram import Update
+from telegram.ext import CallbackContext
+
+import dicers_bot
 
 
-def admin(func):
-    """
-    The function needs to have a keyword parameter named `update` or have the update as the first parameter after self.
-    The admin key is determined by `self.state.get("main_id")`.
+class Command:
+    def __init__(self, chat_admin: bool = False, main_admin: bool = False):
+        self.chat_admin = chat_admin
+        self.main_admin = main_admin
 
-    The admin decorator executes the given function if:
-    - the `update` argument is `None`
-    - the chat_id from update (`update.message.chat_id`) matches the main chat id (`Bot.state["main_id"]`)
-    - `main_id` is `None`
+    @staticmethod
+    def _add_chat(clazz, update: Update, context: CallbackContext):
+        chat = clazz.chats.get(update.effective_chat.id)
+        if not chat:
+            chat = dicers_bot.Chat(update.effective_chat.id, clazz.updater.bot)
+            clazz.chats[chat.id] = chat
 
-    Examples:
-    @admin
-    def require_admin(self, *, update: Update):
-        [...]
+        context.chat_data["chat"] = chat
 
-    @admin
-    def require_admin_2(self, update: Update):
-        [...]
+        if not chat.title:
+            chat.title = update.effective_chat.title
 
-    :param func: Func] -> Any
-    :return:
-    """
-    @functools.wraps(func)
-    def admin_wrapper(*args, **kwargs):
-        admin_key = args[0].state.get("main_id")
+        return chat
 
-        try:
-            update = kwargs.get("update") or args[1]
-        except IndexError:
-            update = None
+    @staticmethod
+    def _add_user(chat, update: Update, context: CallbackContext):
+        filtered_users = [user for user in chat.users if update.effective_user.id == user.id]
+        if filtered_users:
+            user = filtered_users[0]
+        else:
+            user = dicers_bot.User.from_tuser(update.effective_user)
 
-        if not update or getattr(update, "message", None):
-            if not update or update.message.chat_id == admin_key:
-                return func(*args, **kwargs)
-            else:
-                raise PermissionError("You're not authorized to perform this action")
+        context.user_data["user"] = user
 
-    return admin_wrapper
+        return user
+
+    def __call__(self, func):
+        def wrapped_f(*args, **kwargs):
+            logger = dicers_bot.create_logger(f"command_{func.__name__}")
+            logger.debug("Start")
+
+            signature = inspect.signature(func)
+            arguments = signature.bind(*args, **kwargs).arguments
+
+            clazz: dicers_bot.Bot = arguments.get("self")
+            update = arguments.get("update")
+            context = arguments.get("context")
+            execution_message = f"Executing {func.__name__}"
+            finished_execution_message = f"Finished executing {func.__name__}"
+
+            if not update:
+                logger.debug("Execute function due to coming directly from the bot.")
+
+                logger.debug(execution_message)
+                result = func(*args, **kwargs)
+                logger.debug(finished_execution_message)
+
+                return result
+
+            chat = context.chat_data.get("chat")
+            if not chat:
+                chat = self._add_chat(clazz, update, context)
+
+            user = context.user_data.get("user")
+            if not user:
+                user = self._add_user(chat, update, context)
+
+            chat.add_user(user)
+
+            if self.main_admin:
+                if chat.id == clazz.state.get("main_id"):
+                    logger.debug("Execute function due to coming from the main_chat")
+                else:
+                    message = f"Chat {chat} is not allowed to perform this action."
+                    logger.warning(message)
+                    clazz.mute_user(chat_id=chat.id, user=user, until_date=timedelta(minutes=15), reason=message)
+                    raise PermissionError()
+
+            if self.chat_admin:
+                admins = chat.administrators()
+                if user in admins:
+                    logger.debug("User is a chat admin and therefore allowed to perform this action, executing")
+                else:
+                    logger.error("User isn't a chat_admin and is not allowed to perform this action.")
+                    raise PermissionError(f"{user} is not allowed to execute this command.")
+
+            if update.message:
+                chat.add_message(update.message)  # Needs user in chat
+
+            logger.debug(execution_message)
+            try:
+                result = func(*args, **kwargs)
+                logger.debug(finished_execution_message)
+                return result
+            except PermissionError:
+                if update.message:
+                    update.message.reply_text("You're not allowed to perform this action.")
+            except Exception as e:
+                # Log for debugging purposes
+                logger.error(str(e), exc_info=True)
+
+                raise e
+            finally:
+                clazz.save_state()
+                logger.debug("End")
+
+        return wrapped_f

--- a/dicers_bot/decorators.py
+++ b/dicers_bot/decorators.py
@@ -89,9 +89,11 @@ class Command:
                 admins = chat.administrators()
                 if user in admins:
                     logger.debug("User is a chat admin and therefore allowed to perform this action, executing")
+                elif chat.type == dicers_bot.chat.ChatType.PRIVATE:
+                    logger.debug("Execute function due to coming from a private chat")
                 else:
                     logger.error("User isn't a chat_admin and is not allowed to perform this action.")
-                    exception = PermissionError(f"{user} is not allowed to execute this command.")
+                    exception = PermissionError()
 
             if update.message:
                 chat.add_message(update.message)  # Needs user in chat

--- a/dicers_bot/decorators.py
+++ b/dicers_bot/decorators.py
@@ -13,7 +13,7 @@ class Command:
         self.main_admin = main_admin
 
     @staticmethod
-    def _add_chat(clazz, update: Update, context: CallbackContext):
+    def _add_chat(clazz, update: Update, context: CallbackContext) -> dicers_bot.chat.Chat:
         chat = clazz.chats.get(update.effective_chat.id)
         if not chat:
             chat = dicers_bot.Chat(update.effective_chat.id, clazz.updater.bot)
@@ -27,7 +27,7 @@ class Command:
         return chat
 
     @staticmethod
-    def _add_user(chat, update: Update, context: CallbackContext):
+    def _add_user(chat, update: Update, context: CallbackContext) -> dicers_bot.user.User:
         filtered_users = [user for user in chat.users if update.effective_user.id == user.id]
         if filtered_users:
             user = filtered_users[0]

--- a/dicers_bot/decorators.py
+++ b/dicers_bot/decorators.py
@@ -65,6 +65,9 @@ class Command:
             if not chat:
                 chat = self._add_chat(clazz, update, context)
 
+            if not clazz.chats.get(chat.id):
+                clazz.chats[chat.id] = chat
+
             user = context.user_data.get("user")
             if not user:
                 user = self._add_user(chat, update, context)

--- a/dicers_bot/event.py
+++ b/dicers_bot/event.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-from typing import Set, Dict
+from typing import Set, Dict, Any, Optional
 
 from dicers_bot.chat import User
 from .logger import create_logger
@@ -15,17 +17,17 @@ class Event:
         self.absentees: Set = set()
         self.logger.info("Created event for {}".format(self.timestamp))
 
-    def add_absentee(self, user):
+    def add_absentee(self, user) -> None:
         self.logger.info("Add absentee {} to event".format(user))
 
-        return self.absentees.add(user)
+        self.absentees.add(user)
 
-    def remove_absentee(self, user):
+    def remove_absentee(self, user) -> None:
         self.logger.info("Remove absentee {} from event".format(user))
         self.absentees.remove(user)
         self.add_attendee(user)
 
-    def add_attendee(self, user: User):
+    def add_attendee(self, user: User) -> None:
         self.logger.info("Add {} to event".format(user))
         try:
             self.remove_absentee(user)
@@ -33,11 +35,11 @@ class Event:
             self.logger.info("User was not in absentees: {}".format(user))
         self.attendees.add(user)
 
-    def remove_attendee(self, user):
+    def remove_attendee(self, user) -> None:
         self.logger.info("Remove {} from event".format(user))
         self.attendees.remove(user)
 
-    def serialize(self) -> Dict:
+    def serialize(self) -> Dict[str, Any]:
         self.logger.info("Serialize event")
         serialized = {
             "timestamp": self.timestamp.strftime(self.date_format),
@@ -48,7 +50,7 @@ class Event:
         return serialized
 
     @classmethod
-    def deserialize(cls, json_object: Dict):
+    def deserialize(cls, json_object: Dict) -> Optional[Event]:
         if not json_object:
             return None
 
@@ -60,7 +62,7 @@ class Event:
         return event
 
     @staticmethod
-    def _next_monday():
+    def _next_monday() -> datetime:
         today = datetime.today()
         weekday = 0
 

--- a/dicers_bot/logger.py
+++ b/dicers_bot/logger.py
@@ -1,7 +1,7 @@
 import logging
 
 
-def create_logger(name: str, level: int = logging.DEBUG):
+def create_logger(name: str, level: int = logging.DEBUG) -> logging.Logger:
     import sys
     logger = logging.Logger(name)
     ch = logging.StreamHandler(sys.stdout)

--- a/dicers_bot/user.py
+++ b/dicers_bot/user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any, Dict, Optional, Set
 
 from telegram import Message
@@ -23,13 +25,13 @@ class User:
     # def __getattr__(self, item):
     #     return getattr(self.internal, item)
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if not isinstance(other, User):
             return False
 
         return other.id == self.id
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return self.name.__hash__()
 
     def __str__(self) -> str:
@@ -44,13 +46,13 @@ class User:
         return f"<{' | '.join([self.name, roll, muted])}>"
 
     @classmethod
-    def from_tuser(cls, chat_user: TUser):
+    def from_tuser(cls, chat_user: TUser) -> User:
         user = User(chat_user.first_name, chat_user.id, chat_user)
 
         return user
 
     @classmethod
-    def deserialize(cls, json: Dict[str, Any]):
+    def deserialize(cls, json: Dict[str, Any]) -> User:
         user = User(json.get("name"), json.get("id"))
         user.muted = json.get("muted", False)
         user.roll = int(json.get("roll", -1))
@@ -58,7 +60,7 @@ class User:
 
         return user
 
-    def serialize(self):
+    def serialize(self) -> Dict[str, Any]:
         return {
             "name": self.name,
             "roll": self.roll,

--- a/main.py
+++ b/main.py
@@ -70,6 +70,8 @@ def start(bot_token: str):
     # MessageHandler
     dispatcher.add_handler(
         MessageHandler(Filters.text, bot.handle_message))
+    dispatcher.add_handler(
+        MessageHandler(Filters.status_update.left_chat_member, bot.handle_left_chat_member))
     dispatcher.add_handler(MessageHandler(Filters.status_update.new_chat_members, bot.new_member))
 
     # ErrorHandler

--- a/main.py
+++ b/main.py
@@ -52,6 +52,7 @@ def start(bot_token: str):
     dispatcher.add_handler(CommandHandler("users", bot.show_users))
     # chat_admin
     dispatcher.add_handler(CommandHandler("reset", bot.reset))
+    dispatcher.add_handler(CommandHandler("delete_chat", bot.delete_chat))
 
     # main_admin
     dispatcher.add_handler(CommandHandler("remind_all", bot.remind_users))

--- a/main.py
+++ b/main.py
@@ -1,12 +1,11 @@
-import sys
-
 import os
+import sys
 import threading
 from datetime import datetime
 
 import sentry_sdk
 from telegram import TelegramError
-from telegram.ext import CommandHandler, Updater, CallbackQueryHandler, MessageHandler, Filters, Job
+from telegram.ext import CommandHandler, Updater, CallbackQueryHandler, MessageHandler, Filters
 
 from dicers_bot import Bot, create_logger
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,7 @@ oauth2client==4.1.3
 pyasn1==0.4.4
 pyasn1-modules==0.2.2
 pycparser==2.18
-python-telegram-bot==11.1.0
-pytz==2018.7
+python-telegram-bot==12.0.0b1
 rsa==4.0
 schedule==0.5.0
 sentry-sdk==0.7.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ rsa==4.0
 sentry-sdk==0.7.4
 six==1.11.0
 uritemplate==3.0.0
-urllib3==1.24.1
+urllib3==1.24.2
 pdoc3==0.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ pyasn1-modules==0.2.2
 pycparser==2.18
 python-telegram-bot==12.0.0b1
 rsa==4.0
-schedule==0.5.0
 sentry-sdk==0.7.4
 six==1.11.0
 uritemplate==3.0.0


### PR DESCRIPTION
Add Command decorator (replaces admin decorator)
Remove admin decorator
Remove unRegister command
Add unregister_main command
Save chat/user in context data
Promote chat member on unmuting
Remove reply markups on reset
Switch to dispatcher.job_queue for scheduling
Remove schedule
Add more feedbacks to user
Don't rely on message.chat_id, use effective_chat.id instead
Move some commands into bot
Add chat title
Add chat administrators
Update permissions
Update commands.md

The drawback with the `Command` decorator is, that it has to be called even without any parameters -> `@Command` will do nothing